### PR TITLE
add custom precision option

### DIFF
--- a/src/test/core_test.cairo
+++ b/src/test/core_test.cairo
@@ -23,7 +23,6 @@ use cubit::types::fixed::FixedDiv;
 use cubit::math::trig::HALF_PI_u128;
 use cubit::math::trig::PI_u128;
 
-
 #[test]
 fn test_into() {
     let a = Fixed::from_unscaled_felt(5);
@@ -80,7 +79,14 @@ fn test_asin() {
 #[available_gas(10000000)]
 fn test_atan() {
     let a = Fixed::new(2_u128 * ONE_u128, false);
-    assert_precise(a.atan(), 20423289048683266000, 'invalid two');
+
+    // use `DEFAULT_PRECISION`
+    assert_precise(a.atan(), 20423289048683266000, 'invalid two', Option::None(()));
+
+    // use `custom_precision` 
+    assert_precise(
+        a.atan(), 20423289048683266000, 'invalid two', Option::Some(184467440737_u128)
+    ); // 1e-8
 }
 
 #[test]
@@ -147,14 +153,14 @@ fn test_ln() {
 #[available_gas(10000000)]
 fn test_log2() {
     let a = Fixed::from_unscaled_felt(32);
-    assert_precise(a.log2(), 5 * ONE, 'invalid log2 32');
+    assert_precise(a.log2(), 5 * ONE, 'invalid log2 32', Option::None(()));
 }
 
 #[test]
 #[available_gas(10000000)]
 fn test_log10() {
     let a = Fixed::from_unscaled_felt(100);
-    assert_precise(a.log10(), 2 * ONE, 'invalid log10');
+    assert_precise(a.log10(), 2 * ONE, 'invalid log10', Option::None(()));
 }
 
 #[test]
@@ -323,7 +329,7 @@ fn test_cos() {
 #[available_gas(10000000)]
 fn test_sin() {
     let a = Fixed::new(HALF_PI_u128, false);
-    assert_precise(a.sin(), ONE, 'invalid half pi');
+    assert_precise(a.sin(), ONE, 'invalid half pi', Option::None(()));
 }
 
 #[test]
@@ -337,40 +343,49 @@ fn test_tan() {
 #[available_gas(10000000)]
 fn test_cosh() {
     let a = Fixed::new_unscaled(2_u128, false);
-    assert_precise(a.cosh(), 69400261068632590000, 'invalid two'); // 3.762195691016423
+    assert_precise(
+        a.cosh(), 69400261068632590000, 'invalid two', Option::None(())
+    ); // 3.762195691016423
 }
 
 #[test]
 #[available_gas(10000000)]
 fn test_sinh() {
     let a = Fixed::new_unscaled(2_u128, false);
-    assert_precise(a.sinh(), 66903765734623805000, 'invalid two'); // 3.6268604077773023
+    assert_precise(
+        a.sinh(), 66903765734623805000, 'invalid two', Option::None(())
+    ); // 3.6268604077773023
 }
 
 #[test]
 #[available_gas(10000000)]
 fn test_tanh() {
     let a = Fixed::new_unscaled(2_u128, false);
-    assert_precise(a.tanh(), 17783170049656136000, 'invalid two'); // 0.9640275800745076
+    assert_precise(
+        a.tanh(), 17783170049656136000, 'invalid two', Option::None(())
+    ); // 0.9640275800745076
 }
 
 #[test]
 #[available_gas(10000000)]
 fn test_acosh() {
     let a = Fixed::new(69400261067392811864_u128, false); // 3.762195691016423
-    assert_precise(a.acosh(), 2 * ONE, 'invalid two');
+    assert_precise(a.acosh(), 2 * ONE, 'invalid two', Option::None(()));
 }
 
 #[test]
 #[available_gas(10000000)]
 fn test_asinh() {
     let a = Fixed::new(66903765733337761105_u128, false); // 3.6268604077773023
-    assert_precise(a.asinh(), 2 * ONE, 'invalid two');
+    assert_precise(a.asinh(), 2 * ONE, 'invalid two', Option::None(()));
 }
 
 #[test]
 #[available_gas(10000000)]
 fn test_atanh() {
     let a = Fixed::new(16602069666338597000, false); // 0.9
-    assert_precise(a.atanh(), 27157656144668970000, 'invalid 0.9'); // 1.4722194895832204
+    assert_precise(
+        a.atanh(), 27157656144668970000, 'invalid 0.9', Option::None(())
+    ); // 1.4722194895832204
 }
+

--- a/src/test/helpers.cairo
+++ b/src/test/helpers.cairo
@@ -11,12 +11,21 @@ use cubit::types::fixed::FixedSub;
 use cubit::types::fixed::FixedPartialEq;
 use cubit::types::fixed::FixedPrint;
 
-const PRECISION: u128 = 1844674407370_u128; // 1e-7
+const DEFAULT_PRECISION: u128 = 1844674407370_u128; // 1e-7
 
-fn assert_precise(result: FixedType, expected: felt252, msg: felt252) {
+// To use `DEFAULT_PRECISION`, final arg is: `Option::None(())`.
+// To use `custom_precision` of 184467440737_u128: `Option::Some(184467440737_u128)`.
+fn assert_precise(
+    result: FixedType, expected: felt252, msg: felt252, custom_precision: Option<u128>
+) {
+    let precision = match custom_precision {
+        Option::Some(val) => val,
+        Option::None(_) => DEFAULT_PRECISION,
+    };
+
     let diff = (result - Fixed::from_felt(expected)).mag;
 
-    if (diff > PRECISION) {
+    if (diff > precision) {
         match withdraw_gas() {
             Option::Some(_) => {},
             Option::None(_) => {
@@ -27,6 +36,6 @@ fn assert_precise(result: FixedType, expected: felt252, msg: felt252) {
         }
 
         result.print();
-        assert(diff <= PRECISION, msg);
+        assert(diff <= precision, msg);
     }
 }

--- a/src/test/hyp_test.cairo
+++ b/src/test/hyp_test.cairo
@@ -11,74 +11,97 @@ use cubit::types::fixed::FixedPartialEq;
 
 use cubit::math::hyp;
 
-
 #[test]
 #[available_gas(10000000)]
 fn test_cosh() {
     let a = Fixed::new_unscaled(2_u128, false);
-    assert_precise(hyp::cosh(a), 69400261068632590000, 'invalid two'); // 3.762195691016423
+    assert_precise(
+        hyp::cosh(a), 69400261068632590000, 'invalid two', Option::None(())
+    ); // 3.762195691016423
 
     let a = Fixed::new(ONE_u128, false);
-    assert_precise(hyp::cosh(a), 28464813555534070000, 'invalid one'); // 1.5430806347841253
+    assert_precise(
+        hyp::cosh(a), 28464813555534070000, 'invalid one', Option::None(())
+    ); // 1.5430806347841253
 
     let a = Fixed::new(0_u128, false);
-    assert_precise(hyp::cosh(a), ONE, 'invalid zero');
+    assert_precise(hyp::cosh(a), ONE, 'invalid zero', Option::None(()));
 
     let a = Fixed::new(ONE_u128, true);
-    assert_precise(hyp::cosh(a), 28464813555534070000, 'invalid neg one'); // 1.5430806347841253
+    assert_precise(
+        hyp::cosh(a), 28464813555534070000, 'invalid neg one', Option::None(())
+    ); // 1.5430806347841253
 
     let a = Fixed::new_unscaled(2_u128, true);
-    assert_precise(hyp::cosh(a), 69400261068632590000, 'invalid neg two'); // 3.762195691016423
+    assert_precise(
+        hyp::cosh(a), 69400261068632590000, 'invalid neg two', Option::None(())
+    ); // 3.762195691016423
 }
 
 #[test]
 #[available_gas(10000000)]
 fn test_sinh() {
     let a = Fixed::new_unscaled(2_u128, false);
-    assert_precise(hyp::sinh(a), 66903765734623805000, 'invalid two'); // 3.6268604077773023
+    assert_precise(
+        hyp::sinh(a), 66903765734623805000, 'invalid two', Option::None(())
+    ); // 3.6268604077773023
 
     let a = Fixed::new(ONE_u128, false);
-    assert_precise(hyp::sinh(a), 21678635654265184000, 'invalid one'); // 1.1752011936029418
+    assert_precise(
+        hyp::sinh(a), 21678635654265184000, 'invalid one', Option::None(())
+    ); // 1.1752011936029418
 
     let a = Fixed::new(0_u128, false);
     assert(hyp::sinh(a).into() == 0, 'invalid zero');
 
     let a = Fixed::new(ONE_u128, true);
-    assert_precise(hyp::sinh(a), -21678635654265184000, 'invalid neg one'); // -1.1752011936029418
+    assert_precise(
+        hyp::sinh(a), -21678635654265184000, 'invalid neg one', Option::None(())
+    ); // -1.1752011936029418
 
     let a = Fixed::new_unscaled(2_u128, true);
-    assert_precise(hyp::sinh(a), -66903765734623805000, 'invalid neg two'); // -3.6268604077773023
+    assert_precise(
+        hyp::sinh(a), -66903765734623805000, 'invalid neg two', Option::None(())
+    ); // -3.6268604077773023
 }
 
 #[test]
 #[available_gas(10000000)]
 fn test_tanh() {
     let a = Fixed::new_unscaled(2_u128, false);
-    assert_precise(hyp::tanh(a), 17783170049656136000, 'invalid two'); // 0.9640275800745076
+    assert_precise(
+        hyp::tanh(a), 17783170049656136000, 'invalid two', Option::None(())
+    ); // 0.9640275800745076
 
     let a = Fixed::new(ONE_u128, false);
-    assert_precise(hyp::tanh(a), 14048932482948833000, 'invalid one'); // 0.7615941559446443
+    assert_precise(
+        hyp::tanh(a), 14048932482948833000, 'invalid one', Option::None(())
+    ); // 0.7615941559446443
 
     let a = Fixed::new(0_u128, false);
     assert(hyp::tanh(a).into() == 0, 'invalid zero');
 
     let a = Fixed::new(ONE_u128, true);
-    assert_precise(hyp::tanh(a), -14048932482948833000, 'invalid neg one'); // -0.7615941559446443
+    assert_precise(
+        hyp::tanh(a), -14048932482948833000, 'invalid neg one', Option::None(())
+    ); // -0.7615941559446443
 
     let a = Fixed::new_unscaled(2_u128, true);
-    assert_precise(hyp::tanh(a), -17783170049656136000, 'invalid neg two'); // 0.9640275800745076
+    assert_precise(
+        hyp::tanh(a), -17783170049656136000, 'invalid neg two', Option::None(())
+    ); // 0.9640275800745076
 }
 
 #[test]
 #[available_gas(10000000)]
 fn test_acosh() {
     let a = Fixed::new(69400261067392811864_u128, false); // 3.762195691016423
-    assert_precise(hyp::acosh(a), 2 * ONE, 'invalid two');
+    assert_precise(hyp::acosh(a), 2 * ONE, 'invalid two', Option::None(()));
 
     let a = Fixed::new(28464813554960036081_u128, false); // 1.5430806347841253
-    assert_precise(hyp::acosh(a), ONE, 'invalid one');
+    assert_precise(hyp::acosh(a), ONE, 'invalid one', Option::None(()));
 
-    let a = Fixed::new(ONE_u128, false);  // 1
+    let a = Fixed::new(ONE_u128, false); // 1
     assert(hyp::acosh(a).into() == 0, 'invalid zero');
 }
 
@@ -86,36 +109,44 @@ fn test_acosh() {
 #[available_gas(10000000)]
 fn test_asinh() {
     let a = Fixed::new(66903765733337761105_u128, false); // 3.6268604077773023
-    assert_precise(hyp::asinh(a), 2 * ONE, 'invalid two');
+    assert_precise(hyp::asinh(a), 2 * ONE, 'invalid two', Option::None(()));
 
     let a = Fixed::new(21678635653511457631_u128, false); // 1.1752011936029418
-    assert_precise(hyp::asinh(a), ONE, 'invalid one');
+    assert_precise(hyp::asinh(a), ONE, 'invalid one', Option::None(()));
 
     let a = Fixed::new(0_u128, false);
     assert(hyp::asinh(a).into() == 0, 'invalid zero');
 
     let a = Fixed::from_felt(-21678635653511457633); // -1.1752011936029418
-    assert_precise(hyp::asinh(a), -ONE, 'invalid neg one');
+    assert_precise(hyp::asinh(a), -ONE, 'invalid neg one', Option::None(()));
 
     let a = Fixed::from_felt(-66903765733337761123); // -3.6268604077773023
-    assert_precise(hyp::asinh(a), -2 * ONE, 'invalid neg two');
+    assert_precise(hyp::asinh(a), -2 * ONE, 'invalid neg two', Option::None(()));
 }
 
 #[test]
 #[available_gas(10000000)]
 fn test_atanh() {
     let a = Fixed::new(16602069666338597000, false); // 0.9
-    assert_precise(hyp::atanh(a), 27157656144668970000, 'invalid 0.9'); // 1.4722194895832204
+    assert_precise(
+        hyp::atanh(a), 27157656144668970000, 'invalid 0.9', Option::None(())
+    ); // 1.4722194895832204
 
     let a = Fixed::new(9223372036854776000, false); // 0.5
-    assert_precise(hyp::atanh(a), 10132909862646469000, 'invalid half'); // 0.5493061443340548
+    assert_precise(
+        hyp::atanh(a), 10132909862646469000, 'invalid half', Option::None(())
+    ); // 0.5493061443340548
 
     let a = Fixed::new(0_u128, false);
     assert(hyp::atanh(a).into() == 0, 'invalid zero');
 
     let a = Fixed::new(9223372036854776000, true); // 0.5
-    assert_precise(hyp::atanh(a), -10132909862646469000, 'invalid neg half'); // 0.5493061443340548
+    assert_precise(
+        hyp::atanh(a), -10132909862646469000, 'invalid neg half', Option::None(())
+    ); // 0.5493061443340548
 
     let a = Fixed::new(16602069666338597000, true); // 0.9
-    assert_precise(hyp::atanh(a), -27157656144668970000, 'invalid -0.9'); // 1.4722194895832204
+    assert_precise(
+        hyp::atanh(a), -27157656144668970000, 'invalid -0.9', Option::None(())
+    ); // 1.4722194895832204
 }

--- a/src/test/math_test.cairo
+++ b/src/test/math_test.cairo
@@ -20,7 +20,6 @@ use cubit::types::fixed::FixedDiv;
 
 use cubit::math::core;
 
-
 #[test]
 fn test_ceil() {
     let a = Fixed::from_felt(53495557813757699680); // 2.9
@@ -109,13 +108,15 @@ fn test_sqrt() {
     assert(core::sqrt(a).into() == ONE, 'invalid one root');
 
     let a = Fixed::from_unscaled_felt(25);
-    assert_precise(core::sqrt(a), 5 * ONE, 'invalid 25 root'); // 5
+    assert_precise(core::sqrt(a), 5 * ONE, 'invalid 25 root', Option::None(())); // 5
 
     let a = Fixed::from_unscaled_felt(81);
-    assert_precise(core::sqrt(a), 9 * ONE, 'invalid 81 root'); // 5
+    assert_precise(core::sqrt(a), 9 * ONE, 'invalid 81 root', Option::None(())); // 9
 
     let a = Fixed::from_felt(1152921504606846976); // 0.0625
-    assert_precise(core::sqrt(a), 4611686018427387904, 'invalid decimal root'); // 0.25
+    assert_precise(
+        core::sqrt(a), 4611686018427387904, 'invalid decimal root', Option::None(())
+    ); // 0.25
 }
 
 #[test]
@@ -135,15 +136,21 @@ fn test_pow_int() {
 
     let a = Fixed::from_unscaled_felt(3);
     let b = Fixed::from_unscaled_felt(-2);
-    assert_precise(core::pow(a, b), 2049638230412172401, 'invalid neg power'); // 0.1111111111111111
+    assert_precise(
+        core::pow(a, b), 2049638230412172401, 'invalid neg power', Option::None(())
+    ); // 0.1111111111111111
 
     let a = Fixed::from_unscaled_felt(-3);
     let b = Fixed::from_unscaled_felt(-2);
-    assert_precise(core::pow(a, b), 2049638230412172401, 'invalid neg base power');
+    assert_precise(
+        core::pow(a, b), 2049638230412172401, 'invalid neg base power', Option::None(())
+    );
 
     let a = Fixed::from_felt(9223372036854775808);
     let b = Fixed::from_unscaled_felt(2);
-    assert_precise(core::pow(a, b), 4611686018427387904, 'invalid frac base power');
+    assert_precise(
+        core::pow(a, b), 4611686018427387904, 'invalid frac base power', Option::None(())
+    );
 }
 
 #[test]
@@ -151,31 +158,41 @@ fn test_pow_int() {
 fn test_pow_frac() {
     let a = Fixed::from_unscaled_felt(3);
     let b = Fixed::from_felt(9223372036854775808); // 0.5
-    assert_precise(core::pow(a, b), 31950697969885030000, 'invalid pos base power'); // 1.7320508075688772
+    assert_precise(
+        core::pow(a, b), 31950697969885030000, 'invalid pos base power', Option::None(())
+    ); // 1.7320508075688772
 
     let a = Fixed::from_felt(2277250555899444146995); // 123.45
     let b = Fixed::from_felt(-27670116110564327424); // -1.5
-    assert_precise(core::pow(a, b), 13448785939318150, 'invalid pos base power'); // 0.0007290601466350622
+    assert_precise(
+        core::pow(a, b), 13448785939318150, 'invalid pos base power', Option::None(())
+    ); // 0.0007290601466350622
 }
 
 #[test]
 #[available_gas(10000000)]
 fn test_exp() {
     let a = Fixed::new_unscaled(2_u128, false);
-    assert_precise(core::exp(a), 136304026803256380000, 'invalid exp of 2'); // 7.3890560989306495
+    assert_precise(
+        core::exp(a), 136304026803256380000, 'invalid exp of 2', Option::None(())
+    ); // 7.3890560989306495
 
     let a = Fixed::new_unscaled(0_u128, false);
     assert(core::exp(a).into() == ONE, 'invalid exp of 0');
 
     let a = Fixed::new_unscaled(2_u128, true);
-    assert_precise(core::exp(a), 2496495334008789000, 'invalid exp of -2'); // 0.1353352832366127
+    assert_precise(
+        core::exp(a), 2496495334008789000, 'invalid exp of -2', Option::None(())
+    ); // 0.1353352832366127
 }
 
 #[test]
 #[available_gas(10000000)]
 fn test_exp2() {
     let a = Fixed::new(27670116110564327424_u128, false); // 1.5
-    assert_precise(core::exp2(a), 52175271301331124000, 'invalid exp2 of 1.5'); // 2.82842712474619
+    assert_precise(
+        core::exp2(a), 52175271301331124000, 'invalid exp2 of 1.5', Option::None(())
+    ); // 2.82842712474619
 
     let a = Fixed::new_unscaled(2_u128, false);
     assert(core::exp2(a).into() == 4 * ONE, 'invalid exp2 of 2'); // 4
@@ -184,10 +201,14 @@ fn test_exp2() {
     assert(core::exp2(a).into() == ONE, 'invalid exp2 of 0');
 
     let a = Fixed::new_unscaled(2_u128, true);
-    assert_precise(core::exp2(a), 4611686018427387904, 'invalid exp2 of -2'); // 0.25
+    assert_precise(
+        core::exp2(a), 4611686018427387904, 'invalid exp2 of -2', Option::None(())
+    ); // 0.25
 
     let a = Fixed::new(27670116110564327424_u128, true); // -1.5
-    assert_precise(core::exp2(a), 6521908912666391000, 'invalid exp2 of -1.5'); // 0.35355339059327373
+    assert_precise(
+        core::exp2(a), 6521908912666391000, 'invalid exp2 of -1.5', Option::None(())
+    ); // 0.35355339059327373
 }
 
 #[test]
@@ -197,30 +218,36 @@ fn test_ln() {
     assert(core::ln(a).into() == 0, 'invalid ln of 1');
 
     let a = Fixed::from_felt(50143449209799256683); // e
-    assert_precise(core::ln(a), ONE, 'invalid ln of e');
+    assert_precise(core::ln(a), ONE, 'invalid ln of e', Option::None(()));
 
     let a = Fixed::from_felt(9223372036854775808); // 0.5
-    assert_precise(core::ln(a), -12786308645202655000, 'invalid ln of 0.5'); // -0.6931471805599453
+    assert_precise(
+        core::ln(a), -12786308645202655000, 'invalid ln of 0.5', Option::None(())
+    ); // -0.6931471805599453
 }
 
 #[test]
 #[available_gas(10000000)]
 fn test_log2() {
     let a = Fixed::from_unscaled_felt(32);
-    assert_precise(core::log2(a), 5 * ONE, 'invalid log2 32');
+    assert_precise(core::log2(a), 5 * ONE, 'invalid log2 32', Option::None(()));
 
     let a = Fixed::from_unscaled_felt(1234);
-    assert_precise(core::log2(a), 189431951710772170000, 'invalid log2 1234'); // 10.269126679149418
+    assert_precise(
+        core::log2(a), 189431951710772170000, 'invalid log2 1234', Option::None(())
+    ); // 10.269126679149418
 
     let a = Fixed::from_felt(1035286617648801165344); // 56.123
-    assert_precise(core::log2(a), 107185179502756360000, 'invalid log2 56.123'); // 5.8105202237568605
+    assert_precise(
+        core::log2(a), 107185179502756360000, 'invalid log2 56.123', Option::None(())
+    ); // 5.8105202237568605
 }
 
 #[test]
 #[available_gas(10000000)]
 fn test_log10() {
     let a = Fixed::from_unscaled_felt(100);
-    assert_precise(core::log10(a), 2 * ONE, 'invalid log10');
+    assert_precise(core::log10(a), 2 * ONE, 'invalid log10', Option::None(()));
 
     let a = Fixed::from_unscaled_felt(1);
     assert(core::log10(a).into() == 0, 'invalid log10');
@@ -316,7 +343,9 @@ fn test_div() {
     let a = Fixed::from_unscaled_felt(10);
     let b = Fixed::from_felt(53495557813757699680); // 2.9
     let c = core::div(a, b);
-    assert_precise(c, 63609462323136390000, 'invalid pos decimal'); // 3.4482758620689657
+    assert_precise(
+        c, 63609462323136390000, 'invalid pos decimal', Option::None(())
+    ); // 3.4482758620689657
 
     let a = Fixed::from_unscaled_felt(10);
     let b = Fixed::from_unscaled_felt(5);
@@ -336,12 +365,16 @@ fn test_div() {
     let a = Fixed::from_unscaled_felt(-10);
     let b = Fixed::from_unscaled_felt(123456789);
     let c = core::div(a, b);
-    assert_precise(c, -1494186283568, 'invalid neg decimal'); // 8.100000073706917e-8
+    assert_precise(
+        c, -1494186283568, 'invalid neg decimal', Option::None(())
+    ); // 8.100000073706917e-8
 
     let a = Fixed::from_unscaled_felt(123456789);
     let b = Fixed::from_unscaled_felt(-10);
     let c = core::div(a, b);
-    assert_precise(c, -227737579084496056114112102, 'invalid neg decimal'); // -12345678.9
+    assert_precise(
+        c, -227737579084496056114112102, 'invalid neg decimal', Option::None(())
+    ); // -12345678.9
 }
 
 #[test]

--- a/src/test/trig_test.cairo
+++ b/src/test/trig_test.cairo
@@ -15,7 +15,6 @@ use cubit::math::trig::HALF_PI_u128;
 use cubit::math::trig::PI_u128;
 use cubit::math::trig;
 
-
 #[test]
 #[available_gas(100000000)]
 fn test_acos() {
@@ -47,25 +46,25 @@ fn test_acos_fail() {
 #[available_gas(100000000)]
 fn test_atan() {
     let a = Fixed::new(2_u128 * ONE_u128, false);
-    assert_precise(trig::atan(a), 20423289048683266000, 'invalid two');
+    assert_precise(trig::atan(a), 20423289048683266000, 'invalid two', Option::None(()));
 
     let a = Fixed::new(ONE_u128, false);
-    assert_precise(trig::atan(a), 14488038916154245000, 'invalid one');
+    assert_precise(trig::atan(a), 14488038916154245000, 'invalid one', Option::None(()));
 
     let a = Fixed::new(ONE_u128 / 2_u128, false);
-    assert_precise(trig::atan(a), 8552788783625223000, 'invalid half');
+    assert_precise(trig::atan(a), 8552788783625223000, 'invalid half', Option::None(()));
 
     let a = Fixed::new(0_u128, false);
     assert(trig::atan(a).into() == 0, 'invalid zero');
 
     let a = Fixed::new(ONE_u128 / 2_u128, true);
-    assert_precise(trig::atan(a), -8552788783625223000, 'invalid neg half');
+    assert_precise(trig::atan(a), -8552788783625223000, 'invalid neg half', Option::None(()));
 
     let a = Fixed::new(ONE_u128, true);
-    assert_precise(trig::atan(a), -14488038916154245000, 'invalid neg one');
+    assert_precise(trig::atan(a), -14488038916154245000, 'invalid neg one', Option::None(()));
 
     let a = Fixed::new(2_u128 * ONE_u128, true);
-    assert_precise(trig::atan(a), -20423289048683266000, 'invalid neg two');
+    assert_precise(trig::atan(a), -20423289048683266000, 'invalid neg two', Option::None(()));
 }
 
 #[test]
@@ -102,41 +101,55 @@ fn test_cos() {
     assert(trig::cos(a).into() == 0, 'invalid half pi');
 
     let a = Fixed::new(HALF_PI_u128 / 2_u128, false);
-    assert_precise(trig::cos(a), 13043817825332783000, 'invalid quarter pi'); // 0.7071067811865475
+    assert_precise(
+        trig::cos(a), 13043817825332783000, 'invalid quarter pi', Option::None(())
+    ); // 0.7071067811865475
 
     let a = Fixed::new(PI_u128, false);
-    assert_precise(trig::cos(a), -18446744073709552000, 'invalid pi');
+    assert_precise(trig::cos(a), -18446744073709552000, 'invalid pi', Option::None(()));
 
     let a = Fixed::new(HALF_PI_u128, true);
     assert(trig::cos(a).into() == -1, 'invalid neg half pi'); // -0.000...
 
     let a = Fixed::new_unscaled(17_u128, false);
-    assert_precise(trig::cos(a), -5075867675505434000, 'invalid 17'); // -0.2751631780463348
+    assert_precise(
+        trig::cos(a), -5075867675505434000, 'invalid 17', Option::None(())
+    ); // -0.2751631780463348
 
     let a = Fixed::new_unscaled(17_u128, true);
-    assert_precise(trig::cos(a), -5075867675505434000, 'invalid -17'); // -0.2751631780463348
+    assert_precise(
+        trig::cos(a), -5075867675505434000, 'invalid -17', Option::None(())
+    ); // -0.2751631780463348
 }
 
 #[test]
 #[available_gas(100000000)]
 fn test_sin() {
     let a = Fixed::new(HALF_PI_u128, false);
-    assert_precise(trig::sin(a), ONE, 'invalid half pi');
+    assert_precise(trig::sin(a), ONE, 'invalid half pi', Option::None(()));
 
     let a = Fixed::new(HALF_PI_u128 / 2_u128, false);
-    assert_precise(trig::sin(a), 13043817825332781000, 'invalid quarter pi'); // 0.7071067811865475
+    assert_precise(
+        trig::sin(a), 13043817825332781000, 'invalid quarter pi', Option::None(())
+    ); // 0.7071067811865475
 
     let a = Fixed::new(PI_u128, false);
     assert(trig::sin(a).into() == 0, 'invalid pi');
 
     let a = Fixed::new(HALF_PI_u128, true);
-    assert_precise(trig::sin(a), -ONE, 'invalid neg half pi'); // 0.9999999999939766
+    assert_precise(
+        trig::sin(a), -ONE, 'invalid neg half pi', Option::None(())
+    ); // 0.9999999999939766
 
     let a = Fixed::new_unscaled(17_u128, false);
-    assert_precise(trig::sin(a), -17734653485808441000, 'invalid 17'); // -0.9613974918793389
+    assert_precise(
+        trig::sin(a), -17734653485808441000, 'invalid 17', Option::None(())
+    ); // -0.9613974918793389
 
     let a = Fixed::new_unscaled(17_u128, true);
-    assert_precise(trig::sin(a), 17734653485808441000, 'invalid -17'); // 0.9613974918793389
+    assert_precise(
+        trig::sin(a), 17734653485808441000, 'invalid -17', Option::None(())
+    ); // 0.9613974918793389
 }
 
 #[test]
@@ -149,8 +162,12 @@ fn test_tan() {
     assert(trig::tan(a).into() == 0, 'invalid pi');
 
     let a = Fixed::new_unscaled(17_u128, false);
-    assert_precise(trig::tan(a), 64451367727204090000, 'invalid 17'); // 3.493917677159002
+    assert_precise(
+        trig::tan(a), 64451367727204090000, 'invalid 17', Option::None(())
+    ); // 3.493917677159002
 
     let a = Fixed::new_unscaled(17_u128, true);
-    assert_precise(trig::tan(a), -64451367727204090000, 'invalid -17'); // -3.493917677159002
+    assert_precise(
+        trig::tan(a), -64451367727204090000, 'invalid -17', Option::None(())
+    ); // -3.493917677159002
 }

--- a/src/test/vec3_test.cairo
+++ b/src/test/vec3_test.cairo
@@ -3,11 +3,14 @@ use cubit::test::helpers::assert_precise;
 use cubit::types::fixed::Fixed;
 use cubit::types::vec3::Vec3;
 
-
 #[test]
 fn test_add() {
-    let a = Vec3::new(Fixed::new(1_u128, false), Fixed::new(2_u128, false), Fixed::new(3_u128, false));
-    let b = Vec3::new(Fixed::new(4_u128, false), Fixed::new(5_u128, false), Fixed::new(6_u128, false));
+    let a = Vec3::new(
+        Fixed::new(1_u128, false), Fixed::new(2_u128, false), Fixed::new(3_u128, false)
+    );
+    let b = Vec3::new(
+        Fixed::new(4_u128, false), Fixed::new(5_u128, false), Fixed::new(6_u128, false)
+    );
     let c = a + b;
     assert(c.x == Fixed::new(5_u128, false), 'invalid add');
     assert(c.y == Fixed::new(7_u128, false), 'invalid add');
@@ -16,8 +19,16 @@ fn test_add() {
 
 #[test]
 fn test_mul() {
-    let a = Vec3::new(Fixed::new_unscaled(1_u128, false), Fixed::new_unscaled(2_u128, false), Fixed::new_unscaled(3_u128, false));
-    let b = Vec3::new(Fixed::new_unscaled(4_u128, false), Fixed::new_unscaled(5_u128, false), Fixed::new_unscaled(6_u128, false));
+    let a = Vec3::new(
+        Fixed::new_unscaled(1_u128, false),
+        Fixed::new_unscaled(2_u128, false),
+        Fixed::new_unscaled(3_u128, false)
+    );
+    let b = Vec3::new(
+        Fixed::new_unscaled(4_u128, false),
+        Fixed::new_unscaled(5_u128, false),
+        Fixed::new_unscaled(6_u128, false)
+    );
     let c = a * b;
     assert(c.x == Fixed::new_unscaled(4_u128, false), 'invalid mul');
     assert(c.y == Fixed::new_unscaled(10_u128, false), 'invalid mul');
@@ -26,8 +37,12 @@ fn test_mul() {
 
 #[test]
 fn test_div() {
-    let a = Vec3::new(Fixed::new(4_u128, false), Fixed::new(10_u128, false), Fixed::new(6_u128, false));
-    let b = Vec3::new(Fixed::new(1_u128, false), Fixed::new(5_u128, false), Fixed::new(3_u128, false));
+    let a = Vec3::new(
+        Fixed::new(4_u128, false), Fixed::new(10_u128, false), Fixed::new(6_u128, false)
+    );
+    let b = Vec3::new(
+        Fixed::new(1_u128, false), Fixed::new(5_u128, false), Fixed::new(3_u128, false)
+    );
     let c = a / b;
     assert(c.x == Fixed::new_unscaled(4_u128, false), 'invalid div');
     assert(c.y == Fixed::new_unscaled(2_u128, false), 'invalid div');
@@ -36,16 +51,28 @@ fn test_div() {
 
 #[test]
 fn test_dot() {
-    let a = Vec3::new(Fixed::new_unscaled(4_u128, false), Fixed::new_unscaled(10_u128, false), Fixed::new_unscaled(6_u128, false));
-    let b = Vec3::new(Fixed::new_unscaled(1_u128, false), Fixed::new_unscaled(5_u128, false), Fixed::new_unscaled(3_u128, false));
+    let a = Vec3::new(
+        Fixed::new_unscaled(4_u128, false),
+        Fixed::new_unscaled(10_u128, false),
+        Fixed::new_unscaled(6_u128, false)
+    );
+    let b = Vec3::new(
+        Fixed::new_unscaled(1_u128, false),
+        Fixed::new_unscaled(5_u128, false),
+        Fixed::new_unscaled(3_u128, false)
+    );
     let c = a.dot(b);
     assert(c == Fixed::new_unscaled(72_u128, false), 'invalid dot');
 }
 
 #[test]
 fn test_sub() {
-    let a = Vec3::new(Fixed::new(4_u128, false), Fixed::new(10_u128, false), Fixed::new(6_u128, false));
-    let b = Vec3::new(Fixed::new(1_u128, false), Fixed::new(5_u128, false), Fixed::new(3_u128, false));
+    let a = Vec3::new(
+        Fixed::new(4_u128, false), Fixed::new(10_u128, false), Fixed::new(6_u128, false)
+    );
+    let b = Vec3::new(
+        Fixed::new(1_u128, false), Fixed::new(5_u128, false), Fixed::new(3_u128, false)
+    );
     let c = a - b;
     assert(c.x == Fixed::new(3_u128, false), 'invalid sub');
     assert(c.y == Fixed::new(5_u128, false), 'invalid sub');
@@ -54,8 +81,16 @@ fn test_sub() {
 
 #[test]
 fn test_cross() {
-    let a = Vec3::new(Fixed::new_unscaled(1_u128, false), Fixed::new_unscaled(2_u128, false), Fixed::new_unscaled(3_u128, false));
-    let b = Vec3::new(Fixed::new_unscaled(4_u128, false), Fixed::new_unscaled(5_u128, false), Fixed::new_unscaled(6_u128, false));
+    let a = Vec3::new(
+        Fixed::new_unscaled(1_u128, false),
+        Fixed::new_unscaled(2_u128, false),
+        Fixed::new_unscaled(3_u128, false)
+    );
+    let b = Vec3::new(
+        Fixed::new_unscaled(4_u128, false),
+        Fixed::new_unscaled(5_u128, false),
+        Fixed::new_unscaled(6_u128, false)
+    );
     let c = a.cross(b);
     assert(c.x == Fixed::new_unscaled(3_u128, true), 'invalid cross1');
     assert(c.y == Fixed::new_unscaled(6_u128, false), 'invalid cross2');
@@ -64,14 +99,22 @@ fn test_cross() {
 
 #[test]
 fn test_norm() {
-    let a = Vec3::new(Fixed::new_unscaled(1_u128, false), Fixed::new_unscaled(2_u128, false), Fixed::new_unscaled(3_u128, false));
+    let a = Vec3::new(
+        Fixed::new_unscaled(1_u128, false),
+        Fixed::new_unscaled(2_u128, false),
+        Fixed::new_unscaled(3_u128, false)
+    );
     let b = a.norm();
-    assert_precise(b, 69021396225323770000, 'invalid norm'); // sqrt(14)
+    assert_precise(b, 69021396225323770000, 'invalid norm', Option::None(())); // sqrt(14)
 }
 
 #[test]
 fn test_abs() {
-    let a = Vec3::new(Fixed::new_unscaled(1_u128, false), Fixed::new_unscaled(2_u128, true), Fixed::new_unscaled(3_u128, true));
+    let a = Vec3::new(
+        Fixed::new_unscaled(1_u128, false),
+        Fixed::new_unscaled(2_u128, true),
+        Fixed::new_unscaled(3_u128, true)
+    );
     let b = a.abs();
     assert(b.x == Fixed::new_unscaled(1_u128, false), 'invalid abs');
     assert(b.y == Fixed::new_unscaled(2_u128, false), 'invalid abs');

--- a/src/test/vec4_test.cairo
+++ b/src/test/vec4_test.cairo
@@ -3,11 +3,20 @@ use cubit::test::helpers::assert_precise;
 use cubit::types::fixed::Fixed;
 use cubit::types::vec4::Vec4;
 
-
 #[test]
 fn test_add() {
-    let a = Vec4::new(Fixed::new(1_u128, false), Fixed::new(2_u128, false), Fixed::new(3_u128, false), Fixed::new(4_u128, false));
-    let b = Vec4::new(Fixed::new(5_u128, false), Fixed::new(6_u128, false), Fixed::new(7_u128, false), Fixed::new(8_u128, false));
+    let a = Vec4::new(
+        Fixed::new(1_u128, false),
+        Fixed::new(2_u128, false),
+        Fixed::new(3_u128, false),
+        Fixed::new(4_u128, false)
+    );
+    let b = Vec4::new(
+        Fixed::new(5_u128, false),
+        Fixed::new(6_u128, false),
+        Fixed::new(7_u128, false),
+        Fixed::new(8_u128, false)
+    );
     let c = a + b;
     assert(c.x == Fixed::new(6_u128, false), 'invalid add');
     assert(c.y == Fixed::new(8_u128, false), 'invalid add');
@@ -17,8 +26,18 @@ fn test_add() {
 
 #[test]
 fn test_sub() {
-    let a = Vec4::new(Fixed::new(1_u128, false), Fixed::new(2_u128, false), Fixed::new(3_u128, false), Fixed::new(4_u128, false));
-    let b = Vec4::new(Fixed::new(5_u128, false), Fixed::new(6_u128, false), Fixed::new(7_u128, false), Fixed::new(8_u128, false));
+    let a = Vec4::new(
+        Fixed::new(1_u128, false),
+        Fixed::new(2_u128, false),
+        Fixed::new(3_u128, false),
+        Fixed::new(4_u128, false)
+    );
+    let b = Vec4::new(
+        Fixed::new(5_u128, false),
+        Fixed::new(6_u128, false),
+        Fixed::new(7_u128, false),
+        Fixed::new(8_u128, false)
+    );
     let c = a - b;
     assert(c.x == Fixed::new(4_u128, true), 'invalid sub');
     assert(c.y == Fixed::new(4_u128, true), 'invalid sub');
@@ -28,8 +47,18 @@ fn test_sub() {
 
 #[test]
 fn test_mul() {
-    let a = Vec4::new(Fixed::new_unscaled(1_u128, false), Fixed::new_unscaled(2_u128, false), Fixed::new_unscaled(3_u128, false), Fixed::new_unscaled(4_u128, false));
-    let b = Vec4::new(Fixed::new_unscaled(5_u128, false), Fixed::new_unscaled(6_u128, false), Fixed::new_unscaled(7_u128, false), Fixed::new_unscaled(8_u128, false));
+    let a = Vec4::new(
+        Fixed::new_unscaled(1_u128, false),
+        Fixed::new_unscaled(2_u128, false),
+        Fixed::new_unscaled(3_u128, false),
+        Fixed::new_unscaled(4_u128, false)
+    );
+    let b = Vec4::new(
+        Fixed::new_unscaled(5_u128, false),
+        Fixed::new_unscaled(6_u128, false),
+        Fixed::new_unscaled(7_u128, false),
+        Fixed::new_unscaled(8_u128, false)
+    );
     let c = a * b;
     assert(c.x == Fixed::new_unscaled(5_u128, false), 'invalid mul');
     assert(c.y == Fixed::new_unscaled(12_u128, false), 'invalid mul');
@@ -39,8 +68,18 @@ fn test_mul() {
 
 #[test]
 fn test_div() {
-    let a = Vec4::new(Fixed::new(15_u128, false), Fixed::new(20_u128, false), Fixed::new(1_u128, false), Fixed::new(8_u128, false));
-    let b = Vec4::new(Fixed::new(5_u128, false), Fixed::new(4_u128, false), Fixed::new(1_u128, false), Fixed::new(4_u128, false));
+    let a = Vec4::new(
+        Fixed::new(15_u128, false),
+        Fixed::new(20_u128, false),
+        Fixed::new(1_u128, false),
+        Fixed::new(8_u128, false)
+    );
+    let b = Vec4::new(
+        Fixed::new(5_u128, false),
+        Fixed::new(4_u128, false),
+        Fixed::new(1_u128, false),
+        Fixed::new(4_u128, false)
+    );
     let c = a / b;
     assert(c.x == Fixed::new_unscaled(3_u128, false), 'invalid div');
     assert(c.y == Fixed::new_unscaled(5_u128, false), 'invalid div');
@@ -50,23 +89,42 @@ fn test_div() {
 
 #[test]
 fn test_dot() {
-    let a = Vec4::new(Fixed::new_unscaled(1_u128, false), Fixed::new_unscaled(2_u128, false), Fixed::new_unscaled(3_u128, false), Fixed::new_unscaled(4_u128, false));
-    let b = Vec4::new(Fixed::new_unscaled(5_u128, false), Fixed::new_unscaled(6_u128, false), Fixed::new_unscaled(7_u128, false), Fixed::new_unscaled(8_u128, false));
+    let a = Vec4::new(
+        Fixed::new_unscaled(1_u128, false),
+        Fixed::new_unscaled(2_u128, false),
+        Fixed::new_unscaled(3_u128, false),
+        Fixed::new_unscaled(4_u128, false)
+    );
+    let b = Vec4::new(
+        Fixed::new_unscaled(5_u128, false),
+        Fixed::new_unscaled(6_u128, false),
+        Fixed::new_unscaled(7_u128, false),
+        Fixed::new_unscaled(8_u128, false)
+    );
     let c = a.dot(b);
     assert(c == Fixed::new_unscaled(70_u128, false), 'invalid dot');
 }
 
 #[test]
 fn test_norm() {
-    let a = Vec4::new(Fixed::new_unscaled(1_u128, false), Fixed::new_unscaled(2_u128, false), Fixed::new_unscaled(3_u128, false), Fixed::new_unscaled(4_u128, false));
+    let a = Vec4::new(
+        Fixed::new_unscaled(1_u128, false),
+        Fixed::new_unscaled(2_u128, false),
+        Fixed::new_unscaled(3_u128, false),
+        Fixed::new_unscaled(4_u128, false)
+    );
     let b = a.norm();
-    assert_precise(b, 101036978416954620000, 'invalid norm'); // sqrt(30)
+    assert_precise(b, 101036978416954620000, 'invalid norm', Option::None(())); // sqrt(30)
 }
-
 
 #[test]
 fn test_abs() {
-    let a = Vec4::new(Fixed::new_unscaled(1_u128, false), Fixed::new_unscaled(2_u128, true), Fixed::new_unscaled(3_u128, true), Fixed::new_unscaled(4_u128, false));
+    let a = Vec4::new(
+        Fixed::new_unscaled(1_u128, false),
+        Fixed::new_unscaled(2_u128, true),
+        Fixed::new_unscaled(3_u128, true),
+        Fixed::new_unscaled(4_u128, false)
+    );
     let b = a.abs();
     assert(b.x == Fixed::new_unscaled(1_u128, false), 'invalid abs');
     assert(b.y == Fixed::new_unscaled(2_u128, false), 'invalid abs');


### PR DESCRIPTION
1. Add `custom_precision` `Option` as 4th argument of `fn assert_precise`. 
2. Change `PRECISION` to `DEFAULT_PRECISION`
3. Create new variable `precision`. Assign value by `match`: 
  - `custom_precision` if passed `Option::Some(custom_precision)`
  - `DEFAULT_PRECISION` if passed `Option::None(())`
4. Updated all tests that use `assert_precise` to include `Option::None(())` as 4th argument.
5. Added second part of test [here ](https://github.com/whatthedev-eth/cubit/blob/aed3dd13224ec51fb9fc69e05c4e2c9f9b9f2ee6/src/test/core_test.cairo#L83)to use `custom_precision` value 