### PR TITLE
feat: Add FixedTryIntoU128 implementation for TryInto<FixedType, u128>

### DIFF
--- a/src/test/math_tests/core_test.cairo
+++ b/src/test/math_tests/core_test.cairo
@@ -39,9 +39,12 @@ fn test_try_into_u128() {
     let b = Fixed::new(5_u128 * ONE_u128, false);
     assert(b.try_into().unwrap() == 5, 'invalid result');
 
+    let c = Fixed::new(PI_u128, false);
+    assert(c.try_into().unwrap() == 3, 'invalid result');
+
     // Zero
-    let c = Fixed::new_unscaled(0_u128, false);
-    assert(c.try_into().unwrap() == 0_u128, 'invalid result');
+    let d = Fixed::new_unscaled(0_u128, false);
+    assert(d.try_into().unwrap() == 0_u128, 'invalid result');
 }
 
 #[test]

--- a/src/test/math_tests/core_test.cairo
+++ b/src/test/math_tests/core_test.cairo
@@ -1,5 +1,5 @@
 use option::OptionTrait;
-use traits::Into;
+use traits::{Into, TryInto};
 
 use cubit::test::helpers::assert_precise;
 
@@ -27,6 +27,28 @@ use cubit::math::trig::PI_u128;
 fn test_into() {
     let a = Fixed::from_unscaled_felt(5);
     assert(a.into() == 5 * ONE, 'invalid result');
+}
+
+#[test]
+fn test_try_into_u128() {
+    // Positive unscaled
+    let a = Fixed::new_unscaled(5_u128, false);
+    assert(a.try_into().unwrap() == 5, 'invalid result');
+
+    // Positive scaled
+    let b = Fixed::new(5_u128 * ONE_u128, false);
+    assert(b.try_into().unwrap() == 5, 'invalid result');
+
+    // Zero
+    let c = Fixed::new_unscaled(0_u128, false);
+    assert(c.try_into().unwrap() == 0_u128, 'invalid result');
+}
+
+#[test]
+#[should_panic]
+fn test_negative_try_into_u128() {
+    let a = Fixed::new_unscaled(1_u128, true);
+    let a: u128 = a.try_into().unwrap();
 }
 
 #[test]
@@ -388,4 +410,3 @@ fn test_atanh() {
         a.atanh(), 27157656144668970000, 'invalid 0.9', Option::None(())
     ); // 1.4722194895832204
 }
-

--- a/src/test/math_tests/trig_test.cairo
+++ b/src/test/math_tests/trig_test.cairo
@@ -91,7 +91,7 @@ fn test_asin() {
 #[available_gas(100000000)]
 fn test_asin_fail() {
     let a = Fixed::new(2_u128 * ONE_u128, false);
-    trig::asin(a).into();
+    trig::asin(a);
 }
 
 #[test]

--- a/src/types/fixed.cairo
+++ b/src/types/fixed.cairo
@@ -220,6 +220,7 @@ impl FixedTryIntoU128 of TryInto<FixedType, u128> {
         if self.sign {
             Option::None(())
         } else {
+            // Unscale the magnitude and round down
             Option::Some(self.mag / ONE_u128)
         }
     }

--- a/src/types/fixed.cairo
+++ b/src/types/fixed.cairo
@@ -8,7 +8,7 @@ use integer::u256_from_felt252;
 use option::OptionTrait;
 use result::ResultTrait;
 use result::ResultTraitImpl;
-use traits::Into;
+use traits::{TryInto, Into};
 
 use cubit::math::core;
 use cubit::math::hyp;
@@ -207,10 +207,20 @@ impl FixedInto of Into<FixedType, felt252> {
     fn into(self: FixedType) -> felt252 {
         let mag_felt = self.mag.into();
 
-        if (self.sign == true) {
+        if self.sign {
             return mag_felt * -1;
         } else {
             return mag_felt * 1;
+        }
+    }
+}
+
+impl FixedTryIntoU128 of TryInto<FixedType, u128> {
+    fn try_into(self: FixedType) -> Option<u128> {
+        if self.sign {
+            Option::None(())
+        } else {
+            Option::Some(self.mag / ONE_u128)
         }
     }
 }


### PR DESCRIPTION
Hi there, this pr implements the `TryInto` trait for `<FixedType, u128>`

Kindly see below for the passing tests locally (I had to exclude some because of this error

```bash
Error: Failed setting up runner.

Caused by:
    Failed calculating gas usage,
```

![image](https://user-images.githubusercontent.com/35031356/236491505-4a312d5b-d4b4-4da3-924c-764edd32c3f9.png)
