### PR TITLE
Add storage packing to public types since it's supported in 2.1.0

### DIFF
--- a/src/f128/math/core.cairo
+++ b/src/f128/math/core.cairo
@@ -195,7 +195,7 @@ fn mul(a: Fixed, b: Fixed) -> Fixed {
     return FixedTrait::new(scaled_u256.low, a.sign ^ b.sign);
 }
 
-#[derive(Copy, Drop, Serde, Store)]
+#[derive(Copy, Drop, Serde)]
 struct f64 {
     mag: u64,
     sign: bool

--- a/src/f128/math/core.cairo
+++ b/src/f128/math/core.cairo
@@ -195,7 +195,7 @@ fn mul(a: Fixed, b: Fixed) -> Fixed {
     return FixedTrait::new(scaled_u256.low, a.sign ^ b.sign);
 }
 
-#[derive(Copy, Drop, Serde)]
+#[derive(Copy, Drop, Serde, Store)]
 struct f64 {
     mag: u64,
     sign: bool

--- a/src/f128/types/fixed.cairo
+++ b/src/f128/types/fixed.cairo
@@ -20,7 +20,7 @@ const MAX_u128: u128 = 340282366920938463463374607431768211455_u128; // 2 ** 128
 
 // STRUCTS
 
-#[derive(Copy, Drop, Serde)]
+#[derive(Copy, Drop, Serde, Store)]
 struct Fixed {
     mag: u128,
     sign: bool

--- a/src/f128/types/vec2.cairo
+++ b/src/f128/types/vec2.cairo
@@ -2,7 +2,7 @@ use debug::PrintTrait;
 
 use cubit::f128::types::fixed::{Fixed, FixedTrait, FixedPrint};
 
-#[derive(Copy, Drop, Serde)]
+#[derive(Copy, Drop, Serde, Store)]
 struct Vec2 {
     x: Fixed,
     y: Fixed

--- a/src/f128/types/vec3.cairo
+++ b/src/f128/types/vec3.cairo
@@ -2,7 +2,7 @@ use debug::PrintTrait;
 
 use cubit::f128::types::fixed::{Fixed, FixedTrait, FixedPrint};
 
-#[derive(Copy, Drop, Serde)]
+#[derive(Copy, Drop, Serde, Store)]
 struct Vec3 {
     x: Fixed,
     y: Fixed,

--- a/src/f128/types/vec4.cairo
+++ b/src/f128/types/vec4.cairo
@@ -2,7 +2,7 @@ use debug::PrintTrait;
 
 use cubit::f128::types::fixed::{Fixed, FixedTrait, FixedPrint};
 
-#[derive(Copy, Drop, Serde)]
+#[derive(Copy, Drop, Serde, Store)]
 struct Vec4 {
     x: Fixed,
     y: Fixed,

--- a/src/f64/types/fixed.cairo
+++ b/src/f64/types/fixed.cairo
@@ -16,7 +16,7 @@ const HALF: u64 = 2147483648; // 2 ** 31
 
 // STRUCTS
 
-#[derive(Copy, Drop, Serde)]
+#[derive(Copy, Drop, Serde, Store)]
 struct Fixed {
     mag: u64,
     sign: bool

--- a/src/f64/types/vec2.cairo
+++ b/src/f64/types/vec2.cairo
@@ -2,7 +2,7 @@ use debug::PrintTrait;
 
 use cubit::f64::types::fixed::{Fixed, FixedTrait, FixedPrint};
 
-#[derive(Copy, Drop, Serde)]
+#[derive(Copy, Drop, Serde, Store)]
 struct Vec2 {
     x: Fixed,
     y: Fixed

--- a/src/f64/types/vec3.cairo
+++ b/src/f64/types/vec3.cairo
@@ -2,7 +2,7 @@ use debug::PrintTrait;
 
 use cubit::f64::types::fixed::{Fixed, FixedTrait, FixedPrint};
 
-#[derive(Copy, Drop, Serde)]
+#[derive(Copy, Drop, Serde, Store)]
 struct Vec3 {
     x: Fixed,
     y: Fixed,

--- a/src/f64/types/vec4.cairo
+++ b/src/f64/types/vec4.cairo
@@ -2,7 +2,7 @@ use debug::PrintTrait;
 
 use cubit::f64::types::fixed::{Fixed, FixedTrait, FixedPrint};
 
-#[derive(Copy, Drop, Serde)]
+#[derive(Copy, Drop, Serde, Store)]
 struct Vec4 {
     x: Fixed,
     y: Fixed,

--- a/src/types/vec2.cairo
+++ b/src/types/vec2.cairo
@@ -2,7 +2,7 @@ use debug::PrintTrait;
 
 use cubit::types::fixed::{Fixed, FixedTrait, FixedPrint};
 
-#[derive(Copy, Drop, Serde)]
+#[derive(Copy, Drop, Serde, Store)]
 struct Vec2 {
     x: Fixed,
     y: Fixed


### PR DESCRIPTION
Depends on (forks off) https://github.com/influenceth/cubit/pull/17 which updates Cubit to Cairo 2.1.0

Since storage packing is now supported, projects won't have to write their own efficient storage derives and cubit can provide this directly.

Note that the storage packing for vec2, vec3 f64 isn't efficient as it could still be packed into one felt but isn't currently. (These types will occupy two felts in storage.)

f64 and f128 storage packing is, however, efficient.