### PR TITLE
Add SerdeLen Support to Fixed type in Cubit

### DIFF
--- a/src/f128/types/fixed.cairo
+++ b/src/f128/types/fixed.cairo
@@ -22,7 +22,7 @@ const MAX_u128: u128 = 340282366920938463463374607431768211455_u128; // 2 ** 128
 
 // STRUCTS
 
-#[derive(Copy, Drop, Serde)]
+#[derive(Copy, Drop, Serde, SerdeLen)]
 struct Fixed {
     mag: u128,
     sign: bool
@@ -430,10 +430,12 @@ impl PackFixed of StorePacking<Fixed, felt252> {
     }
 
     fn unpack(value: felt252) -> Fixed {
-        let (q, r) = U256DivRem::div_rem(value.into(), u256_as_non_zero(0x100000000000000000000000000000000));
+        let (q, r) = U256DivRem::div_rem(
+            value.into(), u256_as_non_zero(0x100000000000000000000000000000000)
+        );
         let mag: u128 = q.try_into().unwrap();
         let sign: bool = r.into() == 1;
-        Fixed {mag: mag, sign: sign}
+        Fixed { mag: mag, sign: sign }
     }
 }
 

--- a/src/f64/types/fixed.cairo
+++ b/src/f64/types/fixed.cairo
@@ -19,7 +19,7 @@ const HALF: u64 = 2147483648; // 2 ** 31
 
 // STRUCTS
 
-#[derive(Copy, Drop, Serde)]
+#[derive(Copy, Drop, Serde, SerdeLen)]
 struct Fixed {
     mag: u64,
     sign: bool
@@ -417,7 +417,7 @@ impl PackFixed of StorePacking<Fixed, felt252> {
         let (q, r) = U128DivRem::div_rem(value_u128, u128_as_non_zero(0x10000000000000000));
         let mag: u64 = q.try_into().unwrap();
         let sign: bool = r.into() == 1;
-        Fixed {mag: mag, sign: sign}
+        Fixed { mag: mag, sign: sign }
     }
 }
 


### PR DESCRIPTION
Summary
Implements SerdeLen on Fixed type in Cubit for enhanced compatibility with dojo DeFi applications.

Context
Our DeFi applications in Dojo rely on Cubit for state management and use Fixed type across multiple components. These components also require serialization and deserialization lengths (SerdeLen), which is currently missing in Cubit's implementation of Fixed type.

Changes
Added SerdeLen trait to Fixed type in Cubit
Impact
This enhancement will provide seamless integration for components that rely on both Fixed type and SerdeLen in our DeFi applications.