### PR TITLE
ci: use setup-scarb action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,20 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Install cairo compiler
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          rustup override set stable && rustup update
-          git clone https://github.com/starkware-libs/cairo
-          cd cairo
-          git checkout v2.1.0
-          cargo build --all --release
-          cd ../
+      - name: Setup Cairo toolchain
+        uses: software-mansion/setup-scarb@v1
+        with:
+            scarb-version: "0.6.1"
 
-      - name: Add Cairo compiler to path
-        run: echo "$(pwd)/cairo/target/release" >> $GITHUB_PATH
-
-      - name: Test the code
-        run: cairo-test .
+      - name: Run tests
+        run: scarb test

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -5,9 +5,6 @@ cairo-version = "2.1.0"
 description = "Math library in Cairo using a 64.64 fixed point representation"
 homepage = "https://github.com/influenceth/cubit"
 
-[scripts]
-test = "cairo-test ."
-
 [lib]
 sierra = false  # Enable Sierra codegen.
 casm = false   # Enable CASM codegen.


### PR DESCRIPTION
Using the [Scarb GitHub action](https://github.com/software-mansion/setup-scarb) to significantly speed up the CI.

I kept it analogous to the setup before - the action uses Scarb [v0.6.1](https://github.com/software-mansion/scarb/releases/tag/v0.6.1) which comes with Cairo v2.1.0.
