### PR TITLE
dev: add f64::from_unscaled_felt

### DIFF
--- a/src/f64/types/fixed.cairo
+++ b/src/f64/types/fixed.cairo
@@ -35,6 +35,7 @@ trait FixedTrait {
     fn new(mag: u64, sign: bool) -> Fixed;
     fn new_unscaled(mag: u64, sign: bool) -> Fixed;
     fn from_felt(val: felt252) -> Fixed;
+    fn from_unscaled_felt(val: felt252) -> Fixed;
 
     // // Math
     fn abs(self: Fixed) -> Fixed;
@@ -92,6 +93,10 @@ impl FixedImpl of FixedTrait {
     fn from_felt(val: felt252) -> Fixed {
         let mag = integer::u64_try_from_felt252(utils::felt_abs(val)).unwrap();
         return FixedTrait::new(mag, utils::felt_sign(val));
+    }
+
+    fn from_unscaled_felt(val: felt252) -> Fixed {
+        return FixedTrait::from_felt(val * ONE.into());
     }
 
     fn abs(self: Fixed) -> Fixed {


### PR DESCRIPTION
I've noticed f64 Fixed is missing `from_unscaled_felt` that's present in the f128 version. This PR adds the method.