### PR TITLE
Revert "Add SerdeLen Support to Fixed type in Cubit"

### DIFF
--- a/src/f128/types/fixed.cairo
+++ b/src/f128/types/fixed.cairo
@@ -22,7 +22,7 @@ const MAX_u128: u128 = 340282366920938463463374607431768211455_u128; // 2 ** 128
 
 // STRUCTS
 
-#[derive(Copy, Drop, Serde, SerdeLen)]
+#[derive(Copy, Drop, Serde)]
 struct Fixed {
     mag: u128,
     sign: bool
@@ -430,12 +430,10 @@ impl PackFixed of StorePacking<Fixed, felt252> {
     }
 
     fn unpack(value: felt252) -> Fixed {
-        let (q, r) = U256DivRem::div_rem(
-            value.into(), u256_as_non_zero(0x100000000000000000000000000000000)
-        );
+        let (q, r) = U256DivRem::div_rem(value.into(), u256_as_non_zero(0x100000000000000000000000000000000));
         let mag: u128 = q.try_into().unwrap();
         let sign: bool = r.into() == 1;
-        Fixed { mag: mag, sign: sign }
+        Fixed {mag: mag, sign: sign}
     }
 }
 

--- a/src/f64/types/fixed.cairo
+++ b/src/f64/types/fixed.cairo
@@ -19,7 +19,7 @@ const HALF: u64 = 2147483648; // 2 ** 31
 
 // STRUCTS
 
-#[derive(Copy, Drop, Serde, SerdeLen)]
+#[derive(Copy, Drop, Serde)]
 struct Fixed {
     mag: u64,
     sign: bool
@@ -422,7 +422,7 @@ impl PackFixed of StorePacking<Fixed, felt252> {
         let (q, r) = U128DivRem::div_rem(value_u128, u128_as_non_zero(0x10000000000000000));
         let mag: u64 = q.try_into().unwrap();
         let sign: bool = r.into() == 1;
-        Fixed { mag: mag, sign: sign }
+        Fixed {mag: mag, sign: sign}
     }
 }
 


### PR DESCRIPTION
Reverting #19 

SerdeLen is a Dojo dependency, it shouldn't be in the Cubit library. That commit is also actually breaking stuff in my Dojo game, took me a while to figure that out 😣