### PR TITLE
🔥 Remove unused var which trigger scarb warnings

### DIFF
--- a/src/f64/math/trig.cairo
+++ b/src/f64/math/trig.cairo
@@ -450,7 +450,6 @@ mod tests {
     #[available_gas(9_000_000_000)]
     fn test_compare_sin() {
         let error = Option::Some(42950); // 1e-5
-        let pi = FixedTrait::new(PI, false);
 
         let MAX: u64 = 256 * 4;
         let mut n: u64 = 0;


### PR DESCRIPTION
Minor modification to remove an unused variable which triggers the following scarb warning on projects that use cubit as dependancy:

```
warning: Unused variable. Consider ignoring by prefixing with `_`.
 --> /Users/.../Library/Caches/com.swmansion.scarb/registry/git/checkouts/cubit-k9rijvovof89o/09cb8c2/src/f64/math/trig.cairo:453:13
        let pi = FixedTrait::new(PI, false);
            ^^
```